### PR TITLE
protecting source code based on $protokollHelperHasBTeil flag

### DIFF
--- a/ProtokollHelper.php
+++ b/ProtokollHelper.php
@@ -91,7 +91,7 @@ $wgHooks['MediaWikiPerformAction'][] = 'ProtectSource';
 
 function ProtectSource( $output, $article, $title, $user, $request ) {
 
-  global $wgActions, $wgUser;
+  	global $wgActions, $wgUser, $protokollHelperHasBTeil;
 
 	$protectSourceText = false;
 
@@ -103,7 +103,7 @@ function ProtectSource( $output, $article, $title, $user, $request ) {
 	//var_dump($request->getVal( 'action' ), $request->getVal( 'diff' ));
 
 	// only block source of protected pages
-	if(strpos($title->getFullText(),"Fachschaftssitzung/") === 0) {
+	if($protokollHelperHasBTeil) {
 		$protectSourceText = "Der Zugang zum Quelltext von Protokollen ist nur aktiven Fachschaftlern möglich.";
 	}
 	if (!$protectSourceText) {

--- a/ProtokollHelper.php
+++ b/ProtokollHelper.php
@@ -91,7 +91,7 @@ $wgHooks['MediaWikiPerformAction'][] = 'ProtectSource';
 
 function ProtectSource( $output, $article, $title, $user, $request ) {
 
-  	global $wgActions, $wgUser, $protokollHelperHasBTeil;
+  	global $wgActions, $wgUser;
 
 	$protectSourceText = false;
 
@@ -103,7 +103,7 @@ function ProtectSource( $output, $article, $title, $user, $request ) {
 	//var_dump($request->getVal( 'action' ), $request->getVal( 'diff' ));
 
 	// only block source of protected pages
-	if($protokollHelperHasBTeil) {
+	if(strpos($article->getPage()->getContent(), '/bteil') !== FALSE) {
 		$protectSourceText = "Der Zugang zum Quelltext von Protokollen ist nur aktiven Fachschaftlern möglich.";
 	}
 	if (!$protectSourceText) {


### PR DESCRIPTION
At the moment, source code is only protected if the page title contains `Fachschaftssitzung` somewhere. However, it should be possible to use `<bteil>` tags all around the wiki.

Shouldn't we check whether the `global $protokollHelperHasBTeil` has been set, as this is already done correctly if and only if tags were discovered?
